### PR TITLE
Update make.sh

### DIFF
--- a/libraries/libfreetype/make.sh
+++ b/libraries/libfreetype/make.sh
@@ -1,5 +1,5 @@
-PKGURL=https://download.savannah.gnu.org/releases/freetype/freetype-2.11.0.tar.gz
-PKGHASH=e9272ae073e35bb65aa39d55e49a309313f007a7
+PKGURL=https://download.savannah.gnu.org/releases/freetype/freetype-2.10.1.tar.gz
+PKGHASH=3296b64ad1e7540289f22e4b6383e26e928b0a20
 
 package_download $PKGURL $PKGHASH
 package_patch


### PR DESCRIPTION
Revert freetype to older version to prevent:
`sfwoff2.c:327: undefined reference to `BrotliDecoderDecompress'`